### PR TITLE
add scroll up, add id on phone/tablets

### DIFF
--- a/src/Pages/ProductInfoPage/ProductInfoPage.scss
+++ b/src/Pages/ProductInfoPage/ProductInfoPage.scss
@@ -41,7 +41,7 @@
         grid-column: 7 / -1;
       }
       @media (min-width: 1200px) {
-        grid-column: 12 / 19;
+        grid-column: 14 / 20;
       }
 
       .info-row {
@@ -212,5 +212,11 @@
 
   @media (min-width: 1200px) {
     margin-top: 0;
+  }
+}
+
+.id-mobile {
+  @media (min-width: 1200px) {
+    display: none;
   }
 }

--- a/src/Pages/ProductInfoPage/ProductInfoPage.tsx
+++ b/src/Pages/ProductInfoPage/ProductInfoPage.tsx
@@ -7,8 +7,7 @@ import { useGadget } from '../../hooks/useGadget';
 import { LinkBack } from '../../Components/LinkBack';
 
 import { ProductImageSlider } from '../../Components/ProductImageSlider';
-/**/
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { FavoriteContext } from '../../context/FavoriteContext';
 import { CartContext } from '../../context/CartContext';
 import { useNavigate } from 'react-router-dom';
@@ -84,6 +83,10 @@ export const ProductInfoPage = () => {
   const price = gadget?.priceDiscount || gadget?.priceRegular;
   const oldPrice = gadget?.priceDiscount ? gadget.priceRegular : null;
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [itemId]);
+
   return (
     <div className={`product-info-page product-info-page--${theme}`}>
       <UrlWay
@@ -105,6 +108,9 @@ export const ProductInfoPage = () => {
               <div className="info-row">
                 <span className="small-text">
                   {translate('Available colors')}
+                </span>
+                <span className="small-text id-mobile">
+                  ID: {gadget?.namespaceId}
                 </span>
               </div>
 


### PR DESCRIPTION
-додав скрол-ап по кліку на нову сторінку товару
-додав відображення id на планшетних і мобільних розширеннях
-посунув на дві колонки по гріду блок з кнопочками, щоб було в рівень з нижнім блоком (на десктопній версії)